### PR TITLE
feat: persist ballot state

### DIFF
--- a/src/utils/votingResults.ts
+++ b/src/utils/votingResults.ts
@@ -40,8 +40,6 @@ export async function getVotingResultData(
   // Step 1: Fetch results from Snapshot
   const proposalData = await fetchSnapshotResults(proposalId);
 
-  console.log("proposalData", proposalData);
-
   // Check if proposal exists
   if (!proposalData) {
     throw new Error("Proposal not found");


### PR DESCRIPTION
From the "SPP2 Voting UI War Room" telegram chat.

<img width="752" alt="image" src="https://github.com/user-attachments/assets/b84cd152-45c9-4482-b86a-fd4efafdb97b" />

- Persist ballot when logging in, out, and changing wallet
- add option to ignore reload of votes when a wallet that has already voted gets connected